### PR TITLE
chore: fix broken endpoints test

### DIFF
--- a/samples/test/quickstart.js
+++ b/samples/test/quickstart.js
@@ -30,12 +30,9 @@ const cwd = path.join(__dirname, '..');
 
 describe('Quickstart', () => {
   it('should run quickstart', async () => {
-    const stdout = execSync(
-      'node ./quickstart.js long-door-651.appspot.com',
-      {
-        cwd,
-      }
-    );
+    const stdout = execSync('node ./quickstart.js long-door-651.appspot.com', {
+      cwd,
+    });
     assert.match(stdout, /serviceConfigId/);
   });
 });

--- a/samples/test/quickstart.js
+++ b/samples/test/quickstart.js
@@ -31,7 +31,7 @@ const cwd = path.join(__dirname, '..');
 describe('Quickstart', () => {
   it('should run quickstart', async () => {
     const stdout = execSync(
-      'node ./quickstart.js test-api-gateway-app-0zjurikbxiw0v.apigateway.long-door-651.cloud.goog',
+      'node ./quickstart.js long-door-651.appspot.com',
       {
         cwd,
       }


### PR DESCRIPTION
Fixes #73 

I have a feeling that this test broke because of overground, so I created another endpoint for now. If it fails again then I'll look further into the restrictions, perhaps making a less scandalous test.